### PR TITLE
Makes Makefile more robust.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-CXXFLAGS += -std=c++11 -Wall -O2
-LDLIBS   += -ldl -lffi -lstdc++
+CXXFLAGS += -std=c++11 -Wall -O2 $(shell pkg-config --cflags libffi)
+LDFLAGS  += $(shell pkg-config --libs libffi)
+LDLIBS   += -ldl -lstdc++
 
 CXX    ?= g++
 FORMAT ?= clang-format-3.5


### PR DESCRIPTION
On Arch Linux (and I assume at least one other distro), `libffi`'s headers aren't in `/usr/include`.