### PR TITLE
Adds ffi-call-errno.

### DIFF
--- a/ffi-glue.cc
+++ b/ffi-glue.cc
@@ -1,8 +1,9 @@
-#include <iostream>
-#include <vector>
-#include <limits>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <iostream>
+#include <limits>
+#include <vector>
 
 #include <ffi.h>
 #include <dlfcn.h>
@@ -42,7 +43,18 @@ std::ostream &operator<<(std::ostream &out, const Value &v) {
   } else if (v.type == &ffi_type_sint64) {
     out << v.value.s64;
   } else if (v.type == &ffi_type_float) {
-    out << v.value.f;
+	float value = v.value.f;
+	if(std::isnan(value)) {
+		out << "0.0e+NaN";
+	} else if(std::isinf(value)) {
+		if(value < 0) {
+			out << "-1.0e+INF";
+		} else {
+			out << "1.0e+INF";
+		}
+	} else {
+	    out << value;
+	}
   } else if (v.type == &ffi_type_double) {
     out << v.value.d;
   } else if (v.type == &ffi_type_pointer) {

--- a/ffi-glue.cc
+++ b/ffi-glue.cc
@@ -56,7 +56,18 @@ std::ostream &operator<<(std::ostream &out, const Value &v) {
 	    out << value;
 	}
   } else if (v.type == &ffi_type_double) {
-    out << v.value.d;
+	double value = v.value.d;
+	if(std::isnan(value)) {
+		out << "0.0e+NaN";
+	} else if(std::isinf(value)) {
+		if(value < 0) {
+			out << "-1.0e+INF";
+		} else {
+			out << "1.0e+INF";
+		}
+	} else {
+	    out << value;
+	}
   } else if (v.type == &ffi_type_pointer) {
     out << "\\" << v.value.ptr;
   } else if (v.type == &ffi_type_void) {

--- a/ffi-glue.cc
+++ b/ffi-glue.cc
@@ -164,7 +164,7 @@ class Machine {
     cifs_.push_back(cif);
   }
 
-  void call() {
+  void call(bool push_errno) {
     void (*function)() = reinterpret_cast<void (*)()>(stack.pop().value.ptr);
     ffi_cif *cif = static_cast<ffi_cif *>(stack.pop().value.ptr);
     int nargs = cif->nargs;
@@ -177,6 +177,8 @@ class Machine {
     for (int i = 0; i < nargs; i++) {
       stack.pop();
     }
+	if(push_errno)
+    	stack.push(errno);
     stack.push(result);
   }
 
@@ -345,7 +347,12 @@ int main() {
 
       /* call */
       case 'c':
-        vm.call();
+        vm.call(false);
+        break;
+
+      /* call with errno */
+      case 'E':
+        vm.call(true);
         break;
 
       /* call */

--- a/ffi-tests.el
+++ b/ffi-tests.el
@@ -26,6 +26,14 @@
            (result (ffi-call nil "cos" [:double :double] v)))
       (should (< (abs (- (cos v) result)) 0.000001)))))
 
+(ert-deftest ffi-errno ()
+  (ffi-test-harness
+	(let* ((result (ffi-call-errno nil "sqrt" [:double :double] -1))
+		   (value (car result))
+		   (errno (cdr result)))
+	  (should (isnan value))
+	  (should (= errno 33))))) ; TODO Have some way to get macros...
+
 (provide 'ffi-tests)
 
 ;;; ffi-tests.el ends here


### PR DESCRIPTION
Adds a version of `ffi-call` that returns a `(value . errno)` pair. This resolves #10, but depends on a resolution to #11 for the test to pass.