### PR TITLE
Implements ffi-deref.

### DIFF
--- a/ffi-glue.cc
+++ b/ffi-glue.cc
@@ -35,9 +35,9 @@ std::ostream &operator<<(std::ostream &out, const Value &v) {
     } else if (v.type == &ffi_type_uint64) {
         out << v.value.u64;
     } else if (v.type == &ffi_type_sint8) {
-        out << v.value.s8;
+        out << static_cast<int>(v.value.s8);
     } else if (v.type == &ffi_type_sint16) {
-        out << static_cast<int>(v.value.u8);
+        out << v.value.s16;
     } else if (v.type == &ffi_type_sint32) {
         out << v.value.s32;
     } else if (v.type == &ffi_type_sint64) {

--- a/ffi-glue.cc
+++ b/ffi-glue.cc
@@ -219,6 +219,65 @@ public:
         out_.write(data, size);
     }
 
+    void read_mem() {
+        int type = std::cin.get();
+        Value out;
+        uint8_t* ptr_bytes = (uint8_t*) stack.pop().value.ptr;
+        size_t offset = stack.pop().value.u64;
+        ptr_bytes -= offset;
+        void* ptr = ptr_bytes;
+        switch(type) {
+        case 'u':
+            out.type = &ffi_type_uint8;
+            out.value.u8 = *static_cast<uint8_t*>(ptr);
+            break;
+        case 'v':
+            out.type = &ffi_type_uint16;
+            out.value.u16 = *static_cast<uint16_t*>(ptr);
+            break;
+        case 'w':
+            out.type = &ffi_type_uint32;
+            out.value.u32 = *static_cast<uint32_t*>(ptr);
+            break;
+        case 'x':
+            out.type = &ffi_type_uint64;
+            out.value.u64 = *static_cast<uint64_t*>(ptr);
+            break;
+        case 'i':
+            out.type = &ffi_type_sint8;
+            out.value.s8 = *static_cast<int8_t*>(ptr);
+            break;
+        case 'j':
+            out.type = &ffi_type_sint16;
+            out.value.s16 = *static_cast<int16_t*>(ptr);
+            break;
+        case 'k':
+            out.type = &ffi_type_sint32;
+            out.value.s32 = *static_cast<int32_t*>(ptr);
+            break;
+        case 'l':
+            out.type = &ffi_type_sint64;
+            out.value.s64 = *static_cast<int64_t*>(ptr);
+            break;
+        case 'f':
+            out.type = &ffi_type_float;
+            out.value.f = *static_cast<float*>(ptr);
+            break;
+        case 'd':
+            out.type = &ffi_type_double;
+            out.value.d = *static_cast<double*>(ptr);
+            break;
+        case 'p':
+            out.type = &ffi_type_pointer;
+            out.value.ptr = *static_cast<void**>(ptr);
+            break;
+        default:
+            std::cerr << "invalid type in read_mem: " << static_cast<char>(type) << std::endl;
+            return;
+        }
+        stack.push(out);
+    }
+
     void free() { delete static_cast<char *>(stack.pop().value.ptr); }
 
     void size() {
@@ -411,6 +470,11 @@ int main() {
         /* dump */
         case 'D':
             vm.dump();
+            break;
+
+        /* read from memory */
+        case 'r':
+            vm.read_mem();
             break;
 
         /* duplicate top value */

--- a/ffi-glue.cc
+++ b/ffi-glue.cc
@@ -27,7 +27,7 @@ struct Value {
 
 std::ostream &operator<<(std::ostream &out, const Value &v) {
     if (v.type == &ffi_type_uint8) {
-        out << v.value.u8;
+        out << static_cast<unsigned int>(v.value.u8);
     } else if (v.type == &ffi_type_uint16) {
         out << v.value.u16;
     } else if (v.type == &ffi_type_uint32) {
@@ -37,7 +37,7 @@ std::ostream &operator<<(std::ostream &out, const Value &v) {
     } else if (v.type == &ffi_type_sint8) {
         out << v.value.s8;
     } else if (v.type == &ffi_type_sint16) {
-        out << v.value.s16;
+        out << static_cast<int>(v.value.u8);
     } else if (v.type == &ffi_type_sint32) {
         out << v.value.s32;
     } else if (v.type == &ffi_type_sint64) {
@@ -222,10 +222,9 @@ public:
     void read_mem() {
         int type = std::cin.get();
         Value out;
-        uint8_t* ptr_bytes = (uint8_t*) stack.pop().value.ptr;
+        uint8_t* ptr_bytes = static_cast<uint8_t*>(stack.pop().value.ptr);
         size_t offset = stack.pop().value.u64;
-        ptr_bytes -= offset;
-        void* ptr = ptr_bytes;
+        void* ptr = ptr_bytes + offset;
         switch(type) {
         case 'u':
             out.type = &ffi_type_uint8;
@@ -296,9 +295,9 @@ public:
     Reader(Machine &vm, std::istream &in) : vm_(vm), in_(in) {};
 
     void read_uint8() {
-        uint8_t i;
+        uint32_t i;
         in_ >> i;
-        vm_.stack.push(i);
+        vm_.stack.push(static_cast<uint8_t>(i));
     }
     void read_uint16() {
         uint16_t i;
@@ -317,9 +316,9 @@ public:
     }
 
     void read_sint8() {
-        int8_t i;
+        int32_t i;
         in_ >> i;
-        vm_.stack.push(i);
+        vm_.stack.push(static_cast<int8_t>(i));
     }
     void read_sint16() {
         int16_t i;

--- a/ffi-tests.el
+++ b/ffi-tests.el
@@ -42,8 +42,9 @@
 (ert-deftest ffi-deref ()
   (ffi-test-harness
     (let* ((ptr (ffi-call nil "malloc" [:pointer :uint64] 4))
-             (len (ffi-call nil "snprintf" [:sint32 :pointer :uint64 :pointer :sint32] ptr 4 "%d" 123)))
-      (should (= 4 len))
+           (len (ffi-call nil "snprintf" [:sint32 :pointer :uint64 :pointer :sint32] ptr 4 "%d" 123)))
+      (should (= 3 len))
+	  (should (equal (ffi-get-string ptr) "123"))
       (let ((one   (ffi-deref ptr :uint8 0))
             (two   (ffi-deref ptr :uint8 1))
             (three (ffi-deref ptr :uint8 2))

--- a/ffi-tests.el
+++ b/ffi-tests.el
@@ -28,29 +28,31 @@
 
 (ert-deftest ffi-errno ()
   (ffi-test-harness
-	(let* ((result (ffi-call-errno nil "sqrt" [:double :double] -1))
-		   (value (car result))
-		   (errno (cdr result)))
-	  (should (isnan value))
-	  (should (= errno 33))))) ; TODO Have some way to get macros...
+    (let* ((result (ffi-call-errno nil "sqrt" [:double :double] -1))
+           (value (car result))
+           (errno (cdr result)))
+      (should (isnan value))
+      (should (= errno 33))))) ; TODO Have some way to get macros...
 
 (ert-deftest ffi-infinity ()
   (ffi-test-harness
-	(let ((result (ffi-call nil "log" [:double :double] 0)))
-	  (should (= -1.0e+INF result)))))
+    (let ((result (ffi-call nil "log" [:double :double] 0)))
+      (should (= -1.0e+INF result)))))
 
 (ert-deftest ffi-deref ()
   (ffi-test-harness
-	(let ((ptr (ffi-call nil "malloc" [:pointer :uint64] 4)))
-	  (ffi-call nil "snprintf" [:sint32 :pointer :uint64 :pointer :sint32] ptr 4 "%d" 123)
-	  (let ((one   (ffi-deref ptr :uint8 0))
-		    (two   (ffi-deref ptr :uint8 1))
-		    (three (ffi-deref ptr :uint8 2))
-		    (null  (ffi-deref ptr :uint8 3)))
-	    (should (= one   49))
-	    (should (= two   50))
-	    (should (= three 51))
-	    (should (= null   0))))))
+    (let* ((ptr (ffi-call nil "malloc" [:pointer :uint64] 4))
+             (len (ffi-call nil "snprintf" [:sint32 :pointer :uint64 :pointer :sint32] ptr 4 "%d" 123)))
+      (should (= 4 len))
+      (let ((one   (ffi-deref ptr :uint8 0))
+            (two   (ffi-deref ptr :uint8 1))
+            (three (ffi-deref ptr :uint8 2))
+            (null  (ffi-deref ptr :uint8 3)))
+        (should (= one   49))
+        (should (= two   50))
+        (should (= three 51))
+        (should (= null   0))
+        (ffi-call nil "free" [:void :pointer] ptr)))))
 
 (provide 'ffi-tests)
 

--- a/ffi-tests.el
+++ b/ffi-tests.el
@@ -39,6 +39,19 @@
 	(let ((result (ffi-call nil "log" [:double :double] 0)))
 	  (should (= -1.0e+INF result)))))
 
+(ert-deftest ffi-deref ()
+  (ffi-test-harness
+	(let ((ptr (ffi-call nil "malloc" [:pointer :uint64] 4)))
+	  (ffi-call nil "snprintf" [:sint32 :pointer :uint64 :pointer :sint32] ptr 4 "%d" 123)
+	  (let ((one   (ffi-deref ptr :uint8 0))
+		    (two   (ffi-deref ptr :uint8 1))
+		    (three (ffi-deref ptr :uint8 2))
+		    (null  (ffi-deref ptr :uint8 3)))
+	    (should (= one   49))
+	    (should (= two   50))
+	    (should (= three 51))
+	    (should (= null   0))))))
+
 (provide 'ffi-tests)
 
 ;;; ffi-tests.el ends here

--- a/ffi.el
+++ b/ffi.el
@@ -217,6 +217,14 @@ the rest are the argument types. Returns a pair (RETURN-VALUE . ERRNO)."
     (ffi-write ffi-context "LD")
     (ffi-read-bytes ffi-context length)))
 
+(defun ffi-deref (pointer type offset)
+  "Reads a value from memory at the given offset from the pointer."
+  (ffi-ensure)
+  (ffi-push ffi-context :uint64 offset)
+  (ffi-push ffi-context :pointer ptr)
+  (ffi-write ffi-context "r" (get type 'ffi-code))
+  (ffi-pop ffi-context))
+
 (provide 'ffi)
 
 ;;; ffi.el ends here


### PR DESCRIPTION
Note that this also changes (fixes) 8-bit types; cin and cout treat both as characters, which breaks the reader.